### PR TITLE
v0.13.1 — hotfix: argon2 0.45.1 SIGSEGV on Alpine (revert to 0.44.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to Faux|Dash will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.13.1] - 2026-07-22
+
+### Fixed
+- **Container crash-loop (SIGSEGV) on 0.13.0** — `argon2` 0.45.1's prebuilt binary segfaults on `require()` under Alpine/musl (the production base image), crashing the server on the first request that loads the auth module. Reverted `argon2` to 0.44.0 (0.45.1 was an opportunistic bump, not a security fix — argon2 was never in the audit findings). Other native modules (`better-sqlite3`, `sharp` 0.35.3) verified loading and operating correctly on Alpine. Deploy verification now includes a local Alpine image build + health check before publishing.
+- **Dockerfile healthcheck used `localhost`** — which resolves to IPv6 `::1` on Alpine while the server binds IPv4 `0.0.0.0`, so a container run outside compose reported unhealthy despite a working app. Switched to `127.0.0.1` (matching the compose healthcheck).
+
 ## [0.13.0] - 2026-07-22
 
 ### Fixed

--- a/Dockerfile
+++ b/Dockerfile
@@ -55,8 +55,10 @@ EXPOSE 8080
 ENV PORT=8080
 ENV HOSTNAME="0.0.0.0"
 
+# Use 127.0.0.1, not localhost: on Alpine `localhost` resolves to IPv6 ::1 but
+# the Next.js server binds IPv4 0.0.0.0, so `localhost` gets connection-refused.
 HEALTHCHECK --interval=30s --timeout=10s --start-period=30s --retries=3 \
-  CMD wget -qO- http://localhost:8080/api/health || exit 1
+  CMD wget -qO- http://127.0.0.1:8080/api/health || exit 1
 
 # Default PUID/PGID (can be overridden at runtime)
 ENV PUID=1000

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fauxdash-homepage",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fauxdash-homepage",
-      "version": "0.13.0",
+      "version": "0.13.1",
       "dependencies": {
         "@dnd-kit/core": "^6.1.0",
         "@dnd-kit/sortable": "^10.0.0",
@@ -28,7 +28,7 @@
         "@radix-ui/react-tabs": "^1.0.4",
         "@radix-ui/react-toast": "^1.1.5",
         "@types/supercluster": "^7.1.3",
-        "argon2": "^0.45.1",
+        "argon2": "^0.44.0",
         "better-sqlite3": "^9.2.2",
         "class-variance-authority": "^0.7.0",
         "clsx": "^2.1.0",
@@ -6179,15 +6179,15 @@
       "license": "MIT"
     },
     "node_modules/argon2": {
-      "version": "0.45.1",
-      "resolved": "https://registry.npmjs.org/argon2/-/argon2-0.45.1.tgz",
-      "integrity": "sha512-skm+/WCjkGqCQxF7FG1LuZXM5yvbFjgbfiCGsud2oLgaDhh6b6dbH0b1EkghbM+xx4Bj8Ape+KKgixoIlWZicQ==",
+      "version": "0.44.0",
+      "resolved": "https://registry.npmjs.org/argon2/-/argon2-0.44.0.tgz",
+      "integrity": "sha512-zHPGN3S55sihSQo0dBbK0A5qpi2R31z7HZDZnry3ifOyj8bZZnpZND2gpmhnRGO1V/d555RwBqIK5W4Mrmv3ig==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "@phc/format": "^1.0.0",
-        "cross-env": "^10.1.0",
-        "node-addon-api": "^8.9.0",
+        "cross-env": "^10.0.0",
+        "node-addon-api": "^8.5.0",
         "node-gyp-build": "^4.8.4"
       },
       "engines": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fauxdash-homepage",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "private": true,
   "scripts": {
     "dev": "next dev",
@@ -32,7 +32,7 @@
     "@radix-ui/react-tabs": "^1.0.4",
     "@radix-ui/react-toast": "^1.1.5",
     "@types/supercluster": "^7.1.3",
-    "argon2": "^0.45.1",
+    "argon2": "^0.44.0",
     "better-sqlite3": "^9.2.2",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.0",


### PR DESCRIPTION
## Hotfix for v0.13.0 deploy crash

**v0.13.0 crash-looped in production** with exit 139 (SIGSEGV). Root cause: **`argon2` 0.45.1's prebuilt binary segfaults on `require()` under Alpine/musl** (the `node:20-alpine` production base), taking the server down on the first request that loads `src/lib/auth.ts`.

The 0.45.1 bump in v0.13.0 was opportunistic — argon2 was never in the audit findings — so reverting to **0.44.0** costs nothing security-wise. 0.44.0 loads and runs correctly on Alpine (verified in the running image and an isolated container). `better-sqlite3` and `sharp` 0.35.3 were both verified fine on Alpine.

### Changes
- Revert `argon2` `^0.45.1` → `^0.44.0`
- Fix Dockerfile healthcheck `localhost` → `127.0.0.1` (Alpine resolves `localhost` to IPv6 `::1` while the server binds IPv4 `0.0.0.0`; the compose healthcheck already used `127.0.0.1`)
- Bump to v0.13.1

### Verification (the gate that was missing on 0.13.0)
Built the **actual Alpine production image locally** and booted it before publishing:
- `argon2` 0.44.0, `better-sqlite3`, and `sharp` all load/operate cleanly
- Container runs with **0 restarts** (0.13.0 had 12) and serves `{"status":"ok"}` on `127.0.0.1:8080/api/health`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
